### PR TITLE
feat(fe): add time block

### DIFF
--- a/frontend/src/components/TimeBlock.vue
+++ b/frontend/src/components/TimeBlock.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { COLOR } from '@/styles/theme'
+defineProps<{
+  member: number
+  club?: 'skkuding' | 'skkud'
+}>()
+</script>
+
+<template>
+  <div :class="member === 8 ? '' : club">{{ member }}</div>
+</template>
+
+<style scoped>
+div {
+  width: v-bind('`${12.5 * member}%`');
+  height: 100%;
+  border-radius: 8px;
+  background-color: v-bind("COLOR['dark-red']");
+  color: white;
+  font-weight: bold;
+  text-align: v-bind("member === 1 ? 'center' : 'right'");
+  padding: v-bind("member === 1 ? '5px 3px' : '5px'");
+}
+.skkuding {
+  background-color: v-bind('COLOR.green');
+}
+.skkud {
+  background-color: v-bind('COLOR.blue');
+}
+</style>

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -5,6 +5,7 @@ html {
 *,
 *::before,
 *::after {
+  box-sizing: border-box;
   margin: 0;
   position: relative;
   font-weight: normal;


### PR DESCRIPTION
## 구현
Time Block 컴포넌트를 구현했습니다
- width를 `%` 값으로 주어 인원수에 따라 너비가 비례하도록 했습니다.
- 인원수가 8인 경우 및 소속에 따라 색깔을 다르게 설정했습니다.

+) `box-sizing: border-box` 추가

close #22 