### PR TITLE
refactor(fe): use on-click-outside and use v-model in modal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@vitejs/plugin-vue": "^4.0.0",
     "@vue/test-utils": "^2.2.6",
     "@vue/tsconfig": "^0.1.3",
+    "@vueuse/components": "^9.12.0",
     "eslint-plugin-vue": "^9.3.0",
     "jsdom": "^20.0.3",
     "npm-run-all": "^4.1.5",

--- a/frontend/src/components/Modal.vue
+++ b/frontend/src/components/Modal.vue
@@ -22,7 +22,9 @@ defineEmits<{
         <h1 class="title">
           {{ title }}
         </h1>
-        <slot />
+        <div class="content">
+          <slot />
+        </div>
         <div class="button-wrapper">
           <Button
             color="red"
@@ -63,7 +65,7 @@ defineEmits<{
   box-shadow: 2px 2px 10px rgba(10, 10, 10, 0.1);
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  margin-top: 0.5rem;
   align-items: center;
   width: 428px;
   min-height: 16rem;
@@ -72,6 +74,10 @@ defineEmits<{
 .title {
   font-weight: bold;
   font-size: v-bind('FONT_SIZE.title');
+}
+.content {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 .button-wrapper {
   display: flex;

--- a/frontend/src/components/Modal.vue
+++ b/frontend/src/components/Modal.vue
@@ -16,7 +16,7 @@ defineEmits<{
 </script>
 
 <template>
-  <div v-if="modelValue" class="modal-wraper">
+  <div v-if="modelValue" class="modal-wrapper">
     <OnClickOutside @trigger="$emit('update:modelValue', false)">
       <div class="modal-container">
         <h1 class="title">
@@ -45,7 +45,7 @@ defineEmits<{
 </template>
 
 <style scoped>
-.modal-wraper {
+.modal-wrapper {
   position: fixed;
   left: 0;
   top: 0;

--- a/frontend/src/components/Modal.vue
+++ b/frontend/src/components/Modal.vue
@@ -1,73 +1,81 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { onClickOutside } from '@vueuse/core'
-import Button from './Button.vue';
-import { FONT_SIZE } from '@/styles/theme'
-const show = ref(false)
-const modalRef = ref(null)
+import Button from './Button.vue'
+import { OnClickOutside } from '@vueuse/components'
+import { FONT_SIZE, COLOR } from '@/styles/theme'
 
-onClickOutside(
-  modalRef,
-  (event) => {
-    show.value = false
-  },
-)
 defineProps<{
-  title: string;
+  title: string
+  modelValue: boolean
 }>()
 
+defineEmits<{
+  (e: 'update:modelValue', modelValue: boolean): void
+  (e: 'cancel', value: void): void
+  (e: 'confirm', value: void): void
+}>()
 </script>
 
 <template>
-  <div v-if="show" class="modal">
-    <div class="inner" ref="modalRef">
-      <h1 class="heading">
-        {{ title }}
-      </h1>
-      <slot />
-      <div id="button-wrapper">
-        <Button color="red">취소</Button>
-        <Button color="green">생성</Button>
+  <div v-if="modelValue" class="modal-wraper">
+    <OnClickOutside @trigger="$emit('update:modelValue', false)">
+      <div class="modal-container">
+        <h1 class="title">
+          {{ title }}
+        </h1>
+        <slot />
+        <div class="button-wrapper">
+          <Button
+            color="red"
+            @click="$emit('cancel'), $emit('update:modelValue', false)"
+          >
+            취소
+          </Button>
+          <Button
+            color="green"
+            @click="$emit('confirm'), $emit('update:modelValue', false)"
+          >
+            확인
+          </Button>
+        </div>
       </div>
-    </div>
+    </OnClickOutside>
   </div>
 </template>
 
 <style scoped>
-.modal {
+.modal-wraper {
   position: fixed;
   left: 0;
   top: 0;
   right: 0;
   bottom: 0;
-  max-width: 100%;
+  width: 100%;
   background: rgba(0, 0, 0, 0.3);
   display: flex;
   justify-content: center;
   align-items: center;
 }
-.inner {
+.modal-container {
   background-color: white;
-  padding: 24px 48px;
-  border-radius: 5px;
-  border: 1px solid lightgrey;
+  padding: 1.5rem 3rem;
+  border-radius: 0.5rem;
+  border: 1px solid v-bind("COLOR['light-gray']");
   box-shadow: 2px 2px 10px rgba(10, 10, 10, 0.1);
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  width: 425px;
+  width: 428px;
+  min-height: 16rem;
+  z-index: 50;
 }
-.heading {
+.title {
   font-weight: bold;
-  font-size: v-bind("FONT_SIZE.title");
+  font-size: v-bind('FONT_SIZE.title');
 }
-#button-wrapper {
+.button-wrapper {
   display: flex;
-  flex-direction: row;
-  justify-content: center;
-}
-Button {
-  margin: 0 15px;
+  justify-content: space-between;
+  width: 10rem;
 }
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,7 @@ importers:
       '@vitejs/plugin-vue': ^4.0.0
       '@vue/test-utils': ^2.2.6
       '@vue/tsconfig': ^0.1.3
+      '@vueuse/components': ^9.12.0
       '@vueuse/core': ^9.10.0
       axios: ^1.2.2
       eslint-plugin-vue: ^9.3.0
@@ -133,6 +134,7 @@ importers:
       '@vitejs/plugin-vue': 4.0.0_vite@4.0.4+vue@3.2.45
       '@vue/test-utils': 2.2.7_vue@3.2.45
       '@vue/tsconfig': 0.1.3_@types+node@18.11.18
+      '@vueuse/components': 9.12.0_vue@3.2.45
       eslint-plugin-vue: 9.8.0_eslint@8.31.0
       jsdom: 20.0.3
       npm-run-all: 4.1.5
@@ -1630,7 +1632,6 @@ packages:
 
   /@types/web-bluetooth/0.0.16:
     resolution: {integrity: sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ==}
-    dev: false
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -1950,6 +1951,17 @@ packages:
       '@types/node': 18.11.18
     dev: true
 
+  /@vueuse/components/9.12.0_vue@3.2.45:
+    resolution: {integrity: sha512-U468xbr2PISuWepeOU4J8zkVj0aDhiFe230oDhnIm8mHtcS9gM2vSKTB32InxTs6kVma60yAGdqBySkyFNX/+w==}
+    dependencies:
+      '@vueuse/core': 9.12.0_vue@3.2.45
+      '@vueuse/shared': 9.12.0_vue@3.2.45
+      vue-demi: 0.13.11_vue@3.2.45
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: true
+
   /@vueuse/core/9.10.0_vue@3.2.45:
     resolution: {integrity: sha512-CxMewME07qeuzuT/AOIQGv0EhhDoojniqU6pC3F8m5VC76L47UT18DcX88kWlP3I7d3qMJ4u/PD8iSRsy3bmNA==}
     dependencies:
@@ -1962,9 +1974,25 @@ packages:
       - vue
     dev: false
 
+  /@vueuse/core/9.12.0_vue@3.2.45:
+    resolution: {integrity: sha512-h/Di8Bvf6xRcvS/PvUVheiMYYz3U0tH3X25YxONSaAUBa841ayMwxkuzx/DGUMCW/wHWzD8tRy2zYmOC36r4sg==}
+    dependencies:
+      '@types/web-bluetooth': 0.0.16
+      '@vueuse/metadata': 9.12.0
+      '@vueuse/shared': 9.12.0_vue@3.2.45
+      vue-demi: 0.13.11_vue@3.2.45
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: true
+
   /@vueuse/metadata/9.10.0:
     resolution: {integrity: sha512-G5VZhgTCapzU9rv0Iq2HBrVOSGzOKb+OE668NxhXNcTjUjwYxULkEhAw70FtRLMZc+hxcFAzDZlKYA0xcwNMuw==}
     dev: false
+
+  /@vueuse/metadata/9.12.0:
+    resolution: {integrity: sha512-9oJ9MM9lFLlmvxXUqsR1wLt1uF7EVbP5iYaHJYqk+G2PbMjY6EXvZeTjbdO89HgoF5cI6z49o2zT/jD9SVoNpQ==}
+    dev: true
 
   /@vueuse/shared/9.10.0_vue@3.2.45:
     resolution: {integrity: sha512-vakHJ2ZRklAzqmcVBL38RS7BxdBA4+5poG9NsSyqJxrt9kz0zX3P5CXMy0Hm6LFbZXUgvKdqAS3pUH1zX/5qTQ==}
@@ -1974,6 +2002,15 @@ packages:
       - '@vue/composition-api'
       - vue
     dev: false
+
+  /@vueuse/shared/9.12.0_vue@3.2.45:
+    resolution: {integrity: sha512-TWuJLACQ0BVithVTRbex4Wf1a1VaRuSpVeyEd4vMUWl54PzlE0ciFUshKCXnlLuD0lxIaLK4Ypj3NXYzZh4+SQ==}
+    dependencies:
+      vue-demi: 0.13.11_vue@3.2.45
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: true
 
   /@webassemblyjs/ast/1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
@@ -7010,7 +7047,6 @@ packages:
         optional: true
     dependencies:
       vue: 3.2.45
-    dev: false
 
   /vue-eslint-parser/9.1.0_eslint@8.31.0:
     resolution: {integrity: sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==}


### PR DESCRIPTION
1. onClickOutside 컴포넌트 이용하여 간단하게 구현했습니다.
2. 모달을 띄울지 여부를 결정하는 show 값을 `v-model`을 이용해 부모컴포넌트에서 조종 가능하게 만들었습니다.
 2-1. 취소/확인 버튼 클릭 시 `cancel`/ `confirm` emit을 보내는 동시에 modal 창 닫음
3. 기타 : css 약간의 수정... class 이름 변경 및 사소한 값 변경

close #62 

사용 예시

```vue
<script setup lang="ts">
  import Button from '@/components/Button.vue'
  import Modal from '@/components/Modal.vue'

  const showModal = ref(false)
  
  function myFunc(){
  // ...
  }
</script>

<template>
  <Button @click="showModal=true">열려라 참깨</Button>
  <Modal title="제목" v-model="showModal" @confirm="myFunc" @cancel="myFunc" > 내용 </Modal>
</template>

```
